### PR TITLE
Hierarchical queries and sub-queries

### DIFF
--- a/src/__tests__/context.spec.ts
+++ b/src/__tests__/context.spec.ts
@@ -17,7 +17,7 @@ describe("Context logic", () => {
        // Get an unpredicatable number
        obj.a = changetype<u32>(c)
 
-       c.ptr = changetype<u32>(obj)
+       c.storage = changetype<u32>(obj)
        const output = c.as<MockObject>()
        expect<u32>(output.a).toBe(obj.a, "context payload should be passed through")
     })

--- a/src/lib/joystream/query/index.ts
+++ b/src/lib/joystream/query/index.ts
@@ -95,8 +95,6 @@ export namespace glue {
     export function NewContext(p: Params): Context {
         const c = new Context()
         c.id = changetype<u32>(c)
-		c.params = p
-		c.root = p
 		c.produce = new ContextualYielder(c)
         return c
     }
@@ -261,11 +259,9 @@ declare namespace response {
 
 export class ContextualYielder {
 	context: Context
-	//filters: Array<FilterFunc>
 	
 	constructor(context: Context) {
 		this.context = context
-        //this.filters = new Array<FilterFunc>(0)
 	}
 
     field(entry: TypedMap<string, JSON>, name: string): void {
@@ -306,11 +302,11 @@ export class Context {
     id: u32
     params: Params | null
 	root: Params | null
-    ptr: u32
+    storage: u32 
 	produce: ContextualYielder
 
     as<T>(): T {
-        return changetype<T>(this.ptr)
+        return changetype<T>(this.storage)
     }
 
 	param<T>(name: string, sourcesList: TypedMap<string, JSON>[] | null = null): T {
@@ -467,7 +463,7 @@ export function DeclareResolver<T extends Resolver>(): ResolverWrapper  {
     return new ResolverWrapper(
         (ctx: Context) => {
             const obj = instantiate<T>()
-            ctx.ptr = changetype<u32>(obj)
+            ctx.storage = changetype<u32>(obj)
             obj.resolve(ctx)
         },
         (): string => {

--- a/src/lib/joystream/query/index.ts
+++ b/src/lib/joystream/query/index.ts
@@ -96,12 +96,17 @@ export namespace glue {
         const c = new Context()
         c.id = changetype<u32>(c)
 		c.params = p
+		c.root = p
 		c.produce = new ContextualYielder(c)
         return c
     }
 
 	export function SetContextParams(c: Context, p: Params): void {
 		c.params = p
+	}
+
+	export function SetContextParent(c: Context, p: Params): void {
+		c.root = p
 	}
 
     export function ResolveQuery(w: ResolverWrapper, c: Context): void {
@@ -299,7 +304,8 @@ export type StringArrayFunc = () => string[]
 
 export class Context {
     id: u32
-    params: Params
+    params: Params | null
+	root: Params | null
     ptr: u32
 	produce: ContextualYielder
 
@@ -307,10 +313,57 @@ export class Context {
         return changetype<T>(this.ptr)
     }
 
-	param<T>(name: string): T {
-		const value = this.params.get(name)
-        assert(value !== null, "Unexpected null param.")
-		return classify<T>(value as JSON)
+	param<T>(name: string, sourcesList: TypedMap<string, JSON>[] | null = null): T {
+		let sources = sourcesList as TypedMap<string, JSON>[]
+
+		if (sourcesList == null) {
+			sources = new Array<TypedMap<string,JSON>>(0)
+			sources.push(this.params as TypedMap<string, JSON>)
+		}
+
+		for (let i = 0; i < sources.length; i++) {
+			if (sources[i] == null) {
+				continue
+			}
+
+			const src = sources[i] as TypedMap<string, JSON>
+			const value = src.get(name)
+
+		    if (value != null) {
+				return classify<T>(value)
+			}
+		}
+
+		return null
+	}
+
+	mustParam<T>(name: string, sources: TypedMap<string, JSON>[] | null = null): T {
+		const value = this.param<T>(name, sources)
+		assert(value != null)
+		return value
+	}
+
+	select<T>(options: T[]): T {
+		for (let i = 0; i < options.length; i++) {
+			if (options[i] != null) {
+				return options[i]
+			}
+		}
+		return null
+	}
+
+	mustSelect<T>(options: T[]): T {
+        const value = this.select<T>(options)
+		assert(value != null)
+		return value
+	}
+
+	parentIfSet(): TypedMap<string, JSON>[] {
+		const output = new Array<TypedMap<string,JSON>>(0)
+		if (this.root != null) {
+			output.push(this.root as TypedMap<string, JSON>)
+		}
+		return output
 	}
 }
 

--- a/src/reference/main.ts
+++ b/src/reference/main.ts
@@ -14,6 +14,11 @@ export namespace types {
 
 // tslint:disable-next-line:no-namespace
 export namespace resolvers {
-    export const forumCategories = DeclareResolver<CategoryList>()
-    export const forumThreads = DeclareResolver<ThreadList>()
+	export namespace Query {
+		export const forumCategories = DeclareResolver<CategoryList>()
+		export const forumThreads = DeclareResolver<ThreadList>()
+	}
+	export namespace Category {
+		export const threads = DeclareResolver<ThreadList>()
+	}
 }

--- a/src/reference/modules/forum/index.ts
+++ b/src/reference/modules/forum/index.ts
@@ -67,12 +67,13 @@ export class ThreadList extends Resolver {
 
             batch.fetch(ctx, (ctx: Context, thread: Thread) => {
 				// Get category ID from parent or args.
-				// This is rather limited at the momebt, because
+				// This is rather limited at the moment, because
 				// we don't check for maximum counts in the category
 				// itself, and we should.
+				// see https://github.com/Joystream/substrate-forum-module/blob/master/src/lib.rs#L515
 				const categoryId = ctx.select<CategoryId>([
 					ctx.param<CategoryId>("id", ctx.parentIfSet()),
-					ctx.param<CategoryId>("catregory"),
+					ctx.param<CategoryId>("category"),
 				])
 				
 				if (categoryId == null) {


### PR DESCRIPTION
See https://github.com/Joystream/query-node-joystream/pull/10 for top-level feature details.

This makes query resolvers aware of their `root` or (`parent`), if they have one, and includes an example implementation from the forum.